### PR TITLE
Update Dependabot sync workflow

### DIFF
--- a/templates/copy-pr-template-to-dependabot-prs.pr-description.md
+++ b/templates/copy-pr-template-to-dependabot-prs.pr-description.md
@@ -4,4 +4,4 @@ This PR adds a GitHub Actions workflow that will post the PR template as a comme
 
 ---
 
-<sup>🤖 This PR was automatically raised by a script. For more details, please visit https://github.com/alphagov/bulk-changer or ask in the [Platform Reliability Slack channel](https://gds.slack.com/archives/CAEDZ4A8N).</sup>
+<sup>🤖 This PR was automatically raised by [a script](https://github.com/alphagov/bulk-changer). For more details, please ask in the [Platform Reliability Slack channel](https://gds.slack.com/archives/CAEDZ4A8N).</sup>

--- a/templates/copy-pr-template-to-dependabot-prs.yaml
+++ b/templates/copy-pr-template-to-dependabot-prs.yaml
@@ -1,22 +1,41 @@
 name: Copy PR template to Dependabot PRs
+
 on:
   pull_request_target:
     types: [opened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   copy_pr_template:
+    name: Copy PR template to Dependabot PR
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v3
 
-      - name: Fetch PR template
-        id: fetch-pr-template
-        uses: juliangruber/read-file-action@v1
+      - name: Post PR template as a comment
+        uses: actions/github-script@v6
         with:
-          path: .github/pull_request_template.md
+          script: |
+            const fs = require('fs')
 
-      - name: Create comment
-        uses: peter-evans/create-or-update-comment@v2
-        with:
-          issue-number: ${{ github.event.number }}
-          body: ${{ steps.fetch-pr-template.outputs.content }}
+            const body = [
+              "pull_request_template.md",
+              ".github/pull_request_template.md",
+              "docs/pull_request_template.md",
+            ].
+              filter(path => fs.existsSync(path)).
+              map(path => fs.readFileSync(path)).
+              join("\n")
+
+            if (body !== "") {
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body
+              })
+            }


### PR DESCRIPTION
[Trello card](https://trello.com/c/AqLwVouU/2981-automatically-include-pr-template-in-dependabot-pr-descriptions-5)

This fixes 2 issues:

1. A failure if the PR template is missing or in a location other than `.github`
2. A permissions issue if the repo is configured to grant workflows read-only access by default

This also includes a small tweak to the PR template.


This has been tested on a personal repo: https://github.com/robinjam/jubilant-couscous/pull/3