### PR TITLE
Improve rate limiting strategy

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
       hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-linux

--- a/lib/bulk_update_file.rb
+++ b/lib/bulk_update_file.rb
@@ -38,8 +38,8 @@ def bulk_update_file(dry_run:, github_token:, file_path:, file_content:, branch:
     existing_file = get_file_contents(repo_name, file_path)
     if !existing_file.nil? && file_content == Base64.decode64(existing_file.content)
       puts "⏭  file already exists with desired content"
-    elsif repo_has_branch?(repo_name, branch)
-      puts "⏭  branch \"#{branch}\" already exists"
+    elsif repo_has_pr?(repo_name, branch)
+      puts "⏭  PR already exists"
     elsif !filter_matches?(repo_name, if_any_exist, if_all_exist, unless_any_exist, unless_all_exist)
       puts "⏭  filters don't match"
     elsif dry_run

--- a/lib/bulk_update_file.rb
+++ b/lib/bulk_update_file.rb
@@ -35,8 +35,8 @@ def bulk_update_file(dry_run:, github_token:, file_path:, file_content:, branch:
       next
     end
 
-    existing_file = get_file_contents(repo_name, file_path)
     pr_exists = repo_has_pr?(repo_name, branch)
+    existing_file = get_file_contents(repo_name, file_path)
     branch_exists = repo_has_branch?(repo_name, branch)
     if !existing_file.nil? && file_content == Base64.decode64(existing_file.content)
       puts "⏭  file already exists with desired content"

--- a/lib/bulk_update_file.rb
+++ b/lib/bulk_update_file.rb
@@ -47,15 +47,19 @@ def bulk_update_file(dry_run:, github_token:, file_path:, file_content:, branch:
     elsif dry_run
       puts "✅ would raise PR (dry run)"
     else
-      create_branch! repo, branch
-      commit_file!(
-        repo,
-        path: file_path,
-        content: file_content,
-        commit_title: pr_title,
-        branch:,
-        sha: existing_file&.sha,
-      )
+      if branch_exists
+        puts "⏭  branch \"#{branch}\" already exists. Creating PR..."
+      else
+        create_branch! repo, branch
+        commit_file!(
+          repo,
+          path: file_path,
+          content: file_content,
+          commit_title: pr_title,
+          branch:,
+          sha: existing_file&.sha,
+        )
+      end
       create_pr! repo, branch: branch, title: pr_title, description: pr_description
 
       puts "✅ PR raised"

--- a/lib/bulk_update_file.rb
+++ b/lib/bulk_update_file.rb
@@ -36,9 +36,11 @@ def bulk_update_file(dry_run:, github_token:, file_path:, file_content:, branch:
     end
 
     existing_file = get_file_contents(repo_name, file_path)
+    pr_exists = repo_has_pr?(repo_name, branch)
+    branch_exists = repo_has_branch?(repo_name, branch)
     if !existing_file.nil? && file_content == Base64.decode64(existing_file.content)
       puts "⏭  file already exists with desired content"
-    elsif repo_has_pr?(repo_name, branch)
+    elsif pr_exists
       puts "⏭  PR already exists"
     elsif !filter_matches?(repo_name, if_any_exist, if_all_exist, unless_any_exist, unless_all_exist)
       puts "⏭  filters don't match"

--- a/lib/rewrite_rate_limit_headers.rb
+++ b/lib/rewrite_rate_limit_headers.rb
@@ -21,6 +21,10 @@ class RewriteRateLimitHeaders < Faraday::Middleware
         # (We add 5 extra seconds for safety, in case the client & server clocks are out of sync)
         headers["RateLimit-Reset"] = Time.at(headers["X-RateLimit-Reset"].to_i + 5).rfc2822
       end
+      if headers["RateLimit-Remaining"] == "0"
+        limit_expires_at = Time.rfc2822(headers["RateLimit-Reset"]).localtime
+        print "[rate limited until #{limit_expires_at.strftime '%H:%M'}] "
+      end
     end
   end
 end

--- a/lib/util.rb
+++ b/lib/util.rb
@@ -56,7 +56,7 @@ end
 
 def repo_has_pr?(repo_name, branch_name)
   org_name = repo_name.split("/").first
-  Octokit.pull_requests(repo_name, head: "#{org_name}:#{branch_name}").count > 0
+  Octokit.pull_requests(repo_name, head: "#{org_name}:#{branch_name}").count.positive?
 rescue Octokit::NotFound
   false
 end

--- a/lib/util.rb
+++ b/lib/util.rb
@@ -53,3 +53,10 @@ def repo_has_branch?(repo_name, branch_name)
 rescue Octokit::NotFound
   false
 end
+
+def repo_has_pr?(repo_name, branch_name)
+  org_name = repo_name.split("/").first
+  Octokit.pull_requests(repo_name, head: "#{org_name}:#{branch_name}").count > 0
+rescue Octokit::NotFound
+  false
+end

--- a/spec/bulk_update_file_spec.rb
+++ b/spec/bulk_update_file_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe "#bulk_update_file" do
   it "skips repos where the file already exists with the desired content" do
     stub_govuk_repos(%w[foo])
     stub_github_repo("foo", contents: { file_path => file_content })
+    stub_github_get_pullrequests("foo", branch)
     expect { call }.to output("[1/1] alphagov/foo ⏭  file already exists with desired content\n").to_stdout
   end
 
@@ -84,6 +85,9 @@ RSpec.describe "#bulk_update_file" do
   it "skips repos where the PR already exists" do
     stub_govuk_repos(%w[foo])
     stub_github_repo("foo", feature_branches: [branch])
+    stub_create_branch_request("foo", branch)
+    stub_create_contents_request("foo", path: file_path, content: file_content, commit_title: pr_title, branch:)
+    stub_create_pull_request("foo", branch:, title: pr_title, description: pr_description)
     stub_github_get_pullrequests("foo", branch)
     expect { call }.to output("[1/1] alphagov/foo ⏭  PR already exists\n").to_stdout
   end

--- a/spec/bulk_update_file_spec.rb
+++ b/spec/bulk_update_file_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe "#bulk_update_file" do
     stub_govuk_repos(%w[foo])
     stub_github_repo("foo", feature_branches: [branch])
     stub_create_branch_request("foo", branch)
-    stub_github_get_pullrequests("foo", branch)
+    stub_github_get_pullrequests("foo", branch, pull_requests:[{}])
     expect { call }.to output("[1/1] alphagov/foo ⏭  PR already exists\n").to_stdout
   end
 

--- a/spec/bulk_update_file_spec.rb
+++ b/spec/bulk_update_file_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "#bulk_update_file" do
     stub_github_repo("foo", feature_branches: [branch])
     stub_create_branch_request("foo", branch)
     stub_create_pull_request("foo", branch:, title: pr_title, description: pr_description)
-    stub_github_get_pullrequests("foo", branch, pull_requests:[{}])
+    stub_github_get_pullrequests("foo", branch, pull_requests: [{}])
     expect { call }.to output("[1/1] alphagov/foo ⏭  PR already exists\n").to_stdout
   end
 
@@ -155,7 +155,7 @@ RSpec.describe "#bulk_update_file" do
         end
       end
 
-    expect { call }.to output("[1/1] alphagov/foo ❌ repo doesn't exist (or we don't have permission)\n").to_stdout
+    expect { call }.to output("[1/1] alphagov/foo [rate limited until #{rate_limit_expires_at.strftime '%H:%M'}] ❌ repo doesn't exist (or we don't have permission)\n").to_stdout
     expect(github_request_stub).to have_been_requested.times(2)
   end
 end

--- a/spec/bulk_update_file_spec.rb
+++ b/spec/bulk_update_file_spec.rb
@@ -65,7 +65,6 @@ RSpec.describe "#bulk_update_file" do
   it "skips repos where the file already exists with the desired content" do
     stub_govuk_repos(%w[foo])
     stub_github_repo("foo", contents: { file_path => file_content })
-    stub_github_get_pullrequests("foo", branch)
     expect { call }.to output("[1/1] alphagov/foo ⏭  file already exists with desired content\n").to_stdout
   end
 
@@ -86,8 +85,6 @@ RSpec.describe "#bulk_update_file" do
     stub_govuk_repos(%w[foo])
     stub_github_repo("foo", feature_branches: [branch])
     stub_create_branch_request("foo", branch)
-    stub_create_contents_request("foo", path: file_path, content: file_content, commit_title: pr_title, branch:)
-    stub_create_pull_request("foo", branch:, title: pr_title, description: pr_description)
     stub_github_get_pullrequests("foo", branch)
     expect { call }.to output("[1/1] alphagov/foo ⏭  PR already exists\n").to_stdout
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,8 +38,8 @@ def stub_github_get_pullrequests(repo_name, branch_name, pull_requests: [])
         status: 200,
         headers: { "Content-Type": "application/json" },
         body: pull_requests.to_json,
-  )
-    
+      )
+
   stub_request(:post, "https://api.github.com/repos/alphagov/#{repo_name}/pulls?head=alphagov:#{branch_name}&per_page=100")
   .to_return(
     status: 200,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,12 +32,12 @@ def stub_govuk_repos(repo_names)
     )
 end
 
- def stub_github_get_pullrequests(repo_name, branch_name)
+ def stub_github_get_pullrequests(repo_name, branch_name, pull_requests: [])
   stub_request(:get, "https://api.github.com/repos/alphagov/#{repo_name}/pulls?head=alphagov:#{branch_name}&per_page=100")
       .to_return(
         status: 200,
         headers: { "Content-Type": "application/json" },
-        body: [{}].to_json,
+        body: pull_requests.to_json,
       )
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,15 @@ def stub_govuk_repos(repo_names)
     )
 end
 
+ def stub_github_get_pullrequests(repo_name, branch_name)
+  stub_request(:get, "https://api.github.com/repos/alphagov/#{repo_name}/pulls?head=alphagov:#{branch_name}&per_page=100")
+      .to_return(
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+        body: [].to_json,
+      )
+  end
+
 def stub_github_repo(repo_name, feature_branches: [], contents: [])
   stub_request(:get, "https://api.github.com/repos/alphagov/#{repo_name}")
     .to_return(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,7 +37,7 @@ end
       .to_return(
         status: 200,
         headers: { "Content-Type": "application/json" },
-        body: [].to_json,
+        body: [{}].to_json,
       )
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,14 +32,21 @@ def stub_govuk_repos(repo_names)
     )
 end
 
- def stub_github_get_pullrequests(repo_name, branch_name, pull_requests: [])
+def stub_github_get_pullrequests(repo_name, branch_name, pull_requests: [])
   stub_request(:get, "https://api.github.com/repos/alphagov/#{repo_name}/pulls?head=alphagov:#{branch_name}&per_page=100")
       .to_return(
         status: 200,
         headers: { "Content-Type": "application/json" },
         body: pull_requests.to_json,
-      )
-  end
+  )
+    
+  stub_request(:post, "https://api.github.com/repos/alphagov/#{repo_name}/pulls?head=alphagov:#{branch_name}&per_page=100")
+  .to_return(
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    body: pull_requests.to_json,
+  )
+end
 
 def stub_github_repo(repo_name, feature_branches: [], contents: [])
   stub_request(:get, "https://api.github.com/repos/alphagov/#{repo_name}")


### PR DESCRIPTION
Rate limits are enforced when there are too many requests to the GitHub API. This causes the user to be unsure of the status of the script. This PR implements a condition to show the user that the rate limit has been enforced and when the rate limit will expire. 

This PR also improves the checks when a PR or branch exists. So that it can determine whether a PR should be created or a PR already exists. 

To check if there are PRs we send an API request using `Octokit` and using the [`pull_requests`](https://octokit.github.io/octokit.rb/Octokit/Client/PullRequests.html) function and if the output count is more than `0` then PR already exists. 

For notifying the user if they are rate limited we check `headers["RateLimit-Remaining"]` and if the remaining is `0` then we know that the user has been rate limited, therefore a message is shown. 

Trello: https://trello.com/c/yvt7oQiW/3065-improve-rate-limiting-strategy-for-bulk-changer-3